### PR TITLE
fix: Remove all traces of web search functionality

### DIFF
--- a/lib/core/models/message_model.dart
+++ b/lib/core/models/message_model.dart
@@ -1,5 +1,3 @@
-import 'web_search_result_model.dart';
-
 enum MessageType { user, assistant }
 
 class Message {
@@ -81,20 +79,4 @@ class Message {
 
   @override
   int get hashCode => id.hashCode;
-}
-
-// A special message type to hold web search results
-class WebSearchMessage extends Message {
-  final WebSearchResult searchResult;
-  final String query;
-
-  WebSearchMessage({
-    required super.id,
-    required this.query,
-    required this.searchResult,
-  }) : super(
-          content: 'Web search results for "$query"',
-          type: MessageType.assistant,
-          timestamp: DateTime.now(),
-        );
 }

--- a/lib/features/chat/widgets/message_bubble.dart
+++ b/lib/features/chat/widgets/message_bubble.dart
@@ -20,8 +20,6 @@ import '../../../core/models/chart_message_model.dart';
 import '../../../core/models/flashcard_message_model.dart';
 import '../../../core/models/quiz_message_model.dart';
 import '../../../core/models/vision_analysis_message_model.dart';
-import '../../../core/models/web_search_result_model.dart';
-import 'web_search_results_widget.dart';
 import '../../../shared/widgets/markdown_message.dart';
 import 'package:google_fonts/google_fonts.dart';
 import '../../../shared/widgets/thinking_animation.dart';
@@ -322,11 +320,6 @@ class _MessageBubbleState extends State<MessageBubble>
                   _buildQuizContent(widget.message as QuizMessage),
                 ] else if (widget.message is VisionAnalysisMessage) ...[
                   _buildVisionAnalysisContent(widget.message as VisionAnalysisMessage),
-                ] else if (widget.message is WebSearchMessage) ...[
-                  WebSearchResultsWidget(
-                    result: (widget.message as WebSearchMessage).searchResult,
-                    query: (widget.message as WebSearchMessage).query,
-                  ),
                 ] else ...[
                   // Regular message content with markdown support
                   MarkdownMessage(


### PR DESCRIPTION
This commit completely removes the web search functionality from the application, fixing the build errors caused by the previous incomplete removal.

The following have been removed:
- The web search service, data model, and results widget.
- The logic in the chat page that handled the `web_search` tool call.
- The `WebSearchMessage` class from the message model.
- The `WebSearchResultsWidget` usage from the message bubble.